### PR TITLE
Date helper

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -7,6 +7,7 @@ export default {
         "^@model(.*)$": "<rootDir>/src/Model/$1",
         "^@component(.*)$": "<rootDir>/src/Components/$1",
         "^@view(.*)$": "<rootDir>/src/Views/$1",
-        "^@page(.*)$": "<rootDir>/src/Pages/$1"
+        "^@page(.*)$": "<rootDir>/src/Pages/$1",
+        "^@helper(.*)$": "<rootDir>/src/Helpers/$1",
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "worklog-ui",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "UI for discovering trends on what you have been doing. Part of the worklog project.",
   "scripts": {
     "start": "vite --port 3000",

--- a/src/API/getWorklogByRange/example.ts
+++ b/src/API/getWorklogByRange/example.ts
@@ -1,6 +1,6 @@
 import { Work } from "@model/work";
 
-import { subDays } from "date-fns";
+import { subDays } from "@helper/date";
 
 const t = new Date();
 

--- a/src/API/getWorklogByRange/getWorklogByRange.ts
+++ b/src/API/getWorklogByRange/getWorklogByRange.ts
@@ -1,6 +1,6 @@
 // import request from "@api/helper";
 
-// import { format } from "date-fns";
+// import { formatRFC3339DateTime } from "@helper/date";
 
 import { Filter } from "@model/filter";
 import { Work } from "@model/work";
@@ -9,7 +9,7 @@ import { exampleDay1, exampleDay2 } from "./example";
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const getWorklogByRange = (f: Filter): Promise<Work[]> => {
-    // return request.get(`work/${format(f.startDate, "yyyy/MM/ddTHHmm")}`);
+    // return request.get(`work/${formatRFC3339DateTime(f.startDate)}`);
     return Promise.resolve([...exampleDay1, ...exampleDay2]);
 };
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import React, { Fragment, useEffect, useState } from "react";
 import { Routes, Route } from "react-router-dom";
 
-import { subDays } from "date-fns";
+import { subDays } from "@helper/date";
 
 import Worklist from "@page/Worklist/Worklist.page";
 import Header from "@view/Header/Header.view";

--- a/src/Components/Details/Details.component.tsx
+++ b/src/Components/Details/Details.component.tsx
@@ -6,7 +6,7 @@ import { Well, Title, Paragraph } from "@zendeskgarden/react-notifications";
 import { Tag } from "@zendeskgarden/react-tags";
 import { PencilIcon, XIcon } from "@heroicons/react/solid";
 
-import { formatDateTime } from "@helper/date";
+import { formatRelativeDateTimeDuration } from "@helper/date";
 import { Work } from "@model/work";
 
 type Props = {
@@ -24,7 +24,7 @@ const Details: React.FC<Props> = (props: Props) => {
                     </Col>
                     <Col sm={4}>
                         <Paragraph>
-                            {formatDateTime(props.work.When, props.work.Duration)}
+                            {formatRelativeDateTimeDuration(props.work.When, props.work.Duration)}
                         </Paragraph>
                     </Col>
                     <Col sm={1}>

--- a/src/Components/Details/Details.component.tsx
+++ b/src/Components/Details/Details.component.tsx
@@ -1,19 +1,12 @@
 import React from "react";
 
-import {
-    format,
-    isSameWeek,
-    isSameDay,
-    isSameHour,
-    isSameMinute,
-} from "date-fns";
-
 import { Button } from "@zendeskgarden/react-buttons";
 import { Grid, Row, Col } from "@zendeskgarden/react-grid";
 import { Well, Title, Paragraph } from "@zendeskgarden/react-notifications";
 import { Tag } from "@zendeskgarden/react-tags";
 import { PencilIcon, XIcon } from "@heroicons/react/solid";
 
+import { formatDateTime } from "@helper/date";
 import { Work } from "@model/work";
 
 type Props = {
@@ -67,27 +60,6 @@ const Details: React.FC<Props> = (props: Props) => {
             </Grid>
         </Well>
     );
-};
-
-export const formatDateTime = (d: Date, dur?: number): string => {
-    return dur && dur > 0 ?
-        `${formatRelativeDate(d)} for ${dur} minutes.` :
-        `${formatRelativeDate(d)}.`;
-};
-
-export const formatRelativeDate = (d: Date): string => {
-    const now = new Date();
-    if (isSameMinute(d, now)) {
-        return "A few seconds ago";
-    } else if (isSameHour(d, now)) {
-        return `This hour at ${format(d, "HH:mm")}`;
-    } else if (isSameDay(d, now)) {
-        return `Today at ${format(d, "HH:mm")}`;
-    } else if (isSameWeek(d, now)) {
-        return `${format(d, "EEEE")} at ${format(d, "HH:mm")}`;
-    } else {
-        return format(d, "do MMMM yyyy HH:mm");
-    }
 };
 
 export default Details;

--- a/src/Components/Details/Details.test.tsx
+++ b/src/Components/Details/Details.test.tsx
@@ -7,7 +7,7 @@ import { subYears, subMonths, subWeeks, subDays, subHours, subMinutes, subSecond
 import Comp from "./Details.component";
 
 import { render, screen } from "@testing-library/react";
-import { formatDateTime, formatRelativeDate } from "@helper/date";
+import { formatRelativeDateTimeDuration, formatRelativeDateTime } from "@helper/date";
 
 describe("App", () => {
     let onCloseCalled = 0;
@@ -48,7 +48,7 @@ describe("App", () => {
             );
 
             expect(screen.getByText(wk.Title));
-            expect(screen.getByText(`${formatDateTime(wk.When)}`));
+            expect(screen.getByText(`${formatRelativeDateTimeDuration(wk.When)}`));
         });
 
         it("Does not have fields", () => {
@@ -58,7 +58,7 @@ describe("App", () => {
 
             expect(screen.queryByText(wk.ID, { exact: false })).toBeNull();
             expect(screen.queryByText(wk.Revision, { exact: false })).toBeNull();
-            expect(screen.queryByText(formatRelativeDate(wk.CreatedAt))).toBeNull();
+            expect(screen.queryByText(formatRelativeDateTime(wk.CreatedAt))).toBeNull();
         });
     });
 
@@ -81,7 +81,7 @@ describe("App", () => {
             );
 
             expect(screen.getByText(wk.Description));
-            expect(screen.getByText(formatDateTime(wk.When, wk.Duration)));
+            expect(screen.getByText(formatRelativeDateTimeDuration(wk.When, wk.Duration)));
             wk.Tags.forEach(e => {
                 expect(screen.getByText(e, { exact: false }));
             });
@@ -115,7 +115,7 @@ describe("App", () => {
                     <Comp onClose={onCloseFn} work={wk} />
                 );
 
-                expect(screen.getByText(formatDateTime(wk.When, wk.Duration)));
+                expect(screen.getByText(formatRelativeDateTimeDuration(wk.When, wk.Duration)));
             });
         });
 
@@ -137,7 +137,7 @@ describe("App", () => {
                     <Comp onClose={onCloseFn} work={wk} />
                 );
 
-                expect(screen.getByText(formatDateTime(wk.When, wk.Duration)));
+                expect(screen.getByText(formatRelativeDateTimeDuration(wk.When, wk.Duration)));
             });
         });
 
@@ -159,7 +159,7 @@ describe("App", () => {
                     <Comp onClose={onCloseFn} work={wk} />
                 );
 
-                expect(screen.getByText(formatDateTime(wk.When, wk.Duration)));
+                expect(screen.getByText(formatRelativeDateTimeDuration(wk.When, wk.Duration)));
             });
         });
 
@@ -181,7 +181,7 @@ describe("App", () => {
                     <Comp onClose={onCloseFn} work={wk} />
                 );
 
-                expect(screen.getByText(formatDateTime(wk.When, wk.Duration)));
+                expect(screen.getByText(formatRelativeDateTimeDuration(wk.When, wk.Duration)));
             });
         });
 
@@ -203,7 +203,7 @@ describe("App", () => {
                     <Comp onClose={onCloseFn} work={wk} />
                 );
 
-                expect(screen.getByText(formatDateTime(wk.When, wk.Duration)));
+                expect(screen.getByText(formatRelativeDateTimeDuration(wk.When, wk.Duration)));
             });
         });
 
@@ -225,7 +225,7 @@ describe("App", () => {
                     <Comp onClose={onCloseFn} work={wk} />
                 );
 
-                expect(screen.getByText(formatDateTime(wk.When, wk.Duration)));
+                expect(screen.getByText(formatRelativeDateTimeDuration(wk.When, wk.Duration)));
             });
         });
 
@@ -247,7 +247,7 @@ describe("App", () => {
                     <Comp onClose={onCloseFn} work={wk} />
                 );
 
-                expect(screen.getByText(formatDateTime(wk.When, wk.Duration)));
+                expect(screen.getByText(formatRelativeDateTimeDuration(wk.When, wk.Duration)));
             });
         });
 
@@ -269,7 +269,7 @@ describe("App", () => {
                     <Comp onClose={onCloseFn} work={wk} />
                 );
 
-                expect(screen.getByText(formatDateTime(wk.When, wk.Duration)));
+                expect(screen.getByText(formatRelativeDateTimeDuration(wk.When, wk.Duration)));
             });
         });
 

--- a/src/Components/Details/Details.test.tsx
+++ b/src/Components/Details/Details.test.tsx
@@ -2,11 +2,12 @@
  * @jest-environment jsdom
  */
 import React from "react";
-import { subYears, subMonths, subWeeks, subDays, subHours, subMinutes, subSeconds, format } from "date-fns";
+import { subYears, subMonths, subWeeks, subDays, subHours, subMinutes, subSeconds } from "date-fns";
 
-import Comp, { formatDateTime, formatRelativeDate } from "./Details.component";
+import Comp from "./Details.component";
 
 import { render, screen } from "@testing-library/react";
+import { formatDateTime, formatRelativeDate } from "@helper/date";
 
 describe("App", () => {
     let onCloseCalled = 0;
@@ -315,92 +316,5 @@ describe("App", () => {
                 expect(screen.getByText(`A few seconds ago for ${wk.Duration} minutes.`));
             });
         });
-    });
-});
-
-describe("Format date time", () => {
-    const now = new Date();
-
-    it("Further ago than a week without duration", () => {
-        const t = new Date(now);
-        t.setDate(t.getDate() - 10);
-        expect(formatDateTime(t)).toContain(format(t, "do MMMM yyyy"));
-        expect(formatDateTime(t)).toContain(format(t, "HH:mm"));
-        expect(formatDateTime(t)).toEqual(format(t, "do MMMM yyyy HH:mm."));
-    });
-
-    describe("Including duration", () => {
-        it("Further ago than a week with a positive duration", () => {
-            const t = new Date(now);
-            const dur = 60;
-            t.setDate(t.getDate() - 10);
-            expect(formatDateTime(t, dur)).toContain(format(t, "do MMMM yyyy"));
-            expect(formatDateTime(t, dur)).toContain(format(t, "HH:mm"));
-            expect(formatDateTime(t, dur)).toContain(`for ${dur} minutes.`);
-            expect(formatDateTime(t, dur)).toEqual(`${format(t, "do MMMM yyyy HH:mm")} for ${dur} minutes.`);
-        });
-
-        it("Further ago than a week with a zero duration", () => {
-            const t = new Date(now);
-            const dur = 0;
-            t.setDate(t.getDate() - 10);
-            expect(formatDateTime(t, dur)).toContain(format(t, "do MMMM yyyy"));
-            expect(formatDateTime(t, dur)).toContain(format(t, "HH:mm"));
-            expect(formatDateTime(t, dur)).toEqual(`${format(t, "do MMMM yyyy HH:mm")}.`);
-        });
-
-        it("Further ago than a week with a negative duration", () => {
-            const t = new Date(now);
-            const dur = -10;
-            t.setDate(t.getDate() - 10);
-            expect(formatDateTime(t, dur)).toContain(format(t, "do MMMM yyyy"));
-            expect(formatDateTime(t, dur)).toContain(format(t, "HH:mm"));
-            expect(formatDateTime(t, dur)).toEqual(`${format(t, "do MMMM yyyy HH:mm")}.`);
-        });
-    });
-
-});
-
-describe("Format relative date", () => {
-    const now = new Date();
-
-    it("Same minute", () => {
-        const t = new Date(now);
-        t.setSeconds(t.getSeconds() - 1);
-        expect(formatRelativeDate(t)).toEqual("A few seconds ago");
-    });
-
-    it("Same hour", () => {
-        const t = new Date(now);
-        t.setMinutes(t.getMinutes() - 1);
-        expect(formatRelativeDate(t)).toContain("This hour at");
-        expect(formatRelativeDate(t)).toContain(format(t, "HH:mm"));
-    });
-
-    it("Same day", () => {
-        const t = new Date(now);
-        t.setHours(t.getHours() - 1);
-        expect(formatRelativeDate(t)).toContain("Today at");
-        expect(formatRelativeDate(t)).toContain(format(t, "HH:mm"));
-    });
-
-    it("Same week", () => {
-        const t = new Date(now);
-        t.setDate(t.getDate() - 1);
-        expect(formatRelativeDate(t)).toContain(format(t, "EEEE"));
-        expect(formatRelativeDate(t)).toContain(format(t, "'at' HH:mm"));
-    });
-
-    it("Further ago than a week", () => {
-        const t = new Date(now);
-        t.setDate(t.getDate() - 10);
-        expect(formatRelativeDate(t)).toContain(format(t, "do MMMM yyyy"));
-        expect(formatRelativeDate(t)).toContain(format(t, "HH:mm"));
-    });
-
-    it("With leading zeros", () => {
-        const t = new Date("01 Jan 2000 00:00:00 GMT");
-        expect(formatRelativeDate(t)).toContain(format(t, "do MMMM yyyy"));
-        expect(formatRelativeDate(t)).toContain(format(t, "HH:mm"));
     });
 });

--- a/src/Components/Preview/Preview.component.tsx
+++ b/src/Components/Preview/Preview.component.tsx
@@ -1,13 +1,12 @@
 import React from "react";
 
-import { format, formatRelative, isSameWeek } from "date-fns";
-
 import { Button } from "@zendeskgarden/react-buttons";
 import { Grid, Row, Col } from "@zendeskgarden/react-grid";
 import { Well, Title, Paragraph } from "@zendeskgarden/react-notifications";
 import { EyeIcon } from "@heroicons/react/solid";
 
 import { Work } from "@model/work";
+import { formatRelativeDateTime } from "@helper/date";
 
 type Props = {
     work: Work,
@@ -23,9 +22,7 @@ const Preview: React.FC<Props> = (props: Props) => {
                         <Title>{props.work.Title}</Title>
                     </Col>
                     <Col sm={5}>
-                        <Paragraph>{isSameWeek(new Date(), props.work.When) ?
-                            formatRelative(props.work.When, new Date()) :
-                            format(props.work.When, "d MMMM yyyy")}
+                        <Paragraph>{formatRelativeDateTime(props.work.When)}
                         </Paragraph>
                     </Col>
                     <Col sm={2}>

--- a/src/Helpers/date.test.ts
+++ b/src/Helpers/date.test.ts
@@ -1,5 +1,5 @@
 import { format } from "date-fns";
-import { formatDateTime, formatRelativeDate } from "./date";
+import { formatRelativeDateTimeDuration, formatRelativeDateTime } from "./date";
 
 describe("Format date time", () => {
     const now = new Date();
@@ -7,9 +7,9 @@ describe("Format date time", () => {
     it("Further ago than a week without duration", () => {
         const t = new Date(now);
         t.setDate(t.getDate() - 10);
-        expect(formatDateTime(t)).toContain(format(t, "do MMMM yyyy"));
-        expect(formatDateTime(t)).toContain(format(t, "HH:mm"));
-        expect(formatDateTime(t)).toEqual(format(t, "do MMMM yyyy HH:mm."));
+        expect(formatRelativeDateTimeDuration(t)).toContain(format(t, "do MMMM yyyy"));
+        expect(formatRelativeDateTimeDuration(t)).toContain(format(t, "HH:mm"));
+        expect(formatRelativeDateTimeDuration(t)).toEqual(format(t, "do MMMM yyyy HH:mm."));
     });
 
     describe("Including duration", () => {
@@ -17,28 +17,28 @@ describe("Format date time", () => {
             const t = new Date(now);
             const dur = 60;
             t.setDate(t.getDate() - 10);
-            expect(formatDateTime(t, dur)).toContain(format(t, "do MMMM yyyy"));
-            expect(formatDateTime(t, dur)).toContain(format(t, "HH:mm"));
-            expect(formatDateTime(t, dur)).toContain(`for ${dur} minutes.`);
-            expect(formatDateTime(t, dur)).toEqual(`${format(t, "do MMMM yyyy HH:mm")} for ${dur} minutes.`);
+            expect(formatRelativeDateTimeDuration(t, dur)).toContain(format(t, "do MMMM yyyy"));
+            expect(formatRelativeDateTimeDuration(t, dur)).toContain(format(t, "HH:mm"));
+            expect(formatRelativeDateTimeDuration(t, dur)).toContain(`for ${dur} minutes.`);
+            expect(formatRelativeDateTimeDuration(t, dur)).toEqual(`${format(t, "do MMMM yyyy HH:mm")} for ${dur} minutes.`);
         });
 
         it("Further ago than a week with a zero duration", () => {
             const t = new Date(now);
             const dur = 0;
             t.setDate(t.getDate() - 10);
-            expect(formatDateTime(t, dur)).toContain(format(t, "do MMMM yyyy"));
-            expect(formatDateTime(t, dur)).toContain(format(t, "HH:mm"));
-            expect(formatDateTime(t, dur)).toEqual(`${format(t, "do MMMM yyyy HH:mm")}.`);
+            expect(formatRelativeDateTimeDuration(t, dur)).toContain(format(t, "do MMMM yyyy"));
+            expect(formatRelativeDateTimeDuration(t, dur)).toContain(format(t, "HH:mm"));
+            expect(formatRelativeDateTimeDuration(t, dur)).toEqual(`${format(t, "do MMMM yyyy HH:mm")}.`);
         });
 
         it("Further ago than a week with a negative duration", () => {
             const t = new Date(now);
             const dur = -10;
             t.setDate(t.getDate() - 10);
-            expect(formatDateTime(t, dur)).toContain(format(t, "do MMMM yyyy"));
-            expect(formatDateTime(t, dur)).toContain(format(t, "HH:mm"));
-            expect(formatDateTime(t, dur)).toEqual(`${format(t, "do MMMM yyyy HH:mm")}.`);
+            expect(formatRelativeDateTimeDuration(t, dur)).toContain(format(t, "do MMMM yyyy"));
+            expect(formatRelativeDateTimeDuration(t, dur)).toContain(format(t, "HH:mm"));
+            expect(formatRelativeDateTimeDuration(t, dur)).toEqual(`${format(t, "do MMMM yyyy HH:mm")}.`);
         });
     });
 });
@@ -49,40 +49,40 @@ describe("Format relative date", () => {
     it("Same minute", () => {
         const t = new Date(now);
         t.setSeconds(t.getSeconds() - 1);
-        expect(formatRelativeDate(t)).toEqual("A few seconds ago");
+        expect(formatRelativeDateTime(t)).toEqual("A few seconds ago");
     });
 
     it("Same hour", () => {
         const t = new Date(now);
         t.setMinutes(t.getMinutes() - 1);
-        expect(formatRelativeDate(t)).toContain("This hour at");
-        expect(formatRelativeDate(t)).toContain(format(t, "HH:mm"));
+        expect(formatRelativeDateTime(t)).toContain("This hour at");
+        expect(formatRelativeDateTime(t)).toContain(format(t, "HH:mm"));
     });
 
     it("Same day", () => {
         const t = new Date(now);
         t.setHours(t.getHours() - 1);
-        expect(formatRelativeDate(t)).toContain("Today at");
-        expect(formatRelativeDate(t)).toContain(format(t, "HH:mm"));
+        expect(formatRelativeDateTime(t)).toContain("Today at");
+        expect(formatRelativeDateTime(t)).toContain(format(t, "HH:mm"));
     });
 
     it("Same week", () => {
         const t = new Date(now);
         t.setDate(t.getDate() - 1);
-        expect(formatRelativeDate(t)).toContain(format(t, "EEEE"));
-        expect(formatRelativeDate(t)).toContain(format(t, "'at' HH:mm"));
+        expect(formatRelativeDateTime(t)).toContain(format(t, "EEEE"));
+        expect(formatRelativeDateTime(t)).toContain(format(t, "'at' HH:mm"));
     });
 
     it("Further ago than a week", () => {
         const t = new Date(now);
         t.setDate(t.getDate() - 10);
-        expect(formatRelativeDate(t)).toContain(format(t, "do MMMM yyyy"));
-        expect(formatRelativeDate(t)).toContain(format(t, "HH:mm"));
+        expect(formatRelativeDateTime(t)).toContain(format(t, "do MMMM yyyy"));
+        expect(formatRelativeDateTime(t)).toContain(format(t, "HH:mm"));
     });
 
     it("With leading zeros", () => {
         const t = new Date("01 Jan 2000 00:00:00 GMT");
-        expect(formatRelativeDate(t)).toContain(format(t, "do MMMM yyyy"));
-        expect(formatRelativeDate(t)).toContain(format(t, "HH:mm"));
+        expect(formatRelativeDateTime(t)).toContain(format(t, "do MMMM yyyy"));
+        expect(formatRelativeDateTime(t)).toContain(format(t, "HH:mm"));
     });
 });

--- a/src/Helpers/date.test.ts
+++ b/src/Helpers/date.test.ts
@@ -1,0 +1,88 @@
+import { format } from "date-fns";
+import { formatDateTime, formatRelativeDate } from "./date";
+
+describe("Format date time", () => {
+    const now = new Date();
+
+    it("Further ago than a week without duration", () => {
+        const t = new Date(now);
+        t.setDate(t.getDate() - 10);
+        expect(formatDateTime(t)).toContain(format(t, "do MMMM yyyy"));
+        expect(formatDateTime(t)).toContain(format(t, "HH:mm"));
+        expect(formatDateTime(t)).toEqual(format(t, "do MMMM yyyy HH:mm."));
+    });
+
+    describe("Including duration", () => {
+        it("Further ago than a week with a positive duration", () => {
+            const t = new Date(now);
+            const dur = 60;
+            t.setDate(t.getDate() - 10);
+            expect(formatDateTime(t, dur)).toContain(format(t, "do MMMM yyyy"));
+            expect(formatDateTime(t, dur)).toContain(format(t, "HH:mm"));
+            expect(formatDateTime(t, dur)).toContain(`for ${dur} minutes.`);
+            expect(formatDateTime(t, dur)).toEqual(`${format(t, "do MMMM yyyy HH:mm")} for ${dur} minutes.`);
+        });
+
+        it("Further ago than a week with a zero duration", () => {
+            const t = new Date(now);
+            const dur = 0;
+            t.setDate(t.getDate() - 10);
+            expect(formatDateTime(t, dur)).toContain(format(t, "do MMMM yyyy"));
+            expect(formatDateTime(t, dur)).toContain(format(t, "HH:mm"));
+            expect(formatDateTime(t, dur)).toEqual(`${format(t, "do MMMM yyyy HH:mm")}.`);
+        });
+
+        it("Further ago than a week with a negative duration", () => {
+            const t = new Date(now);
+            const dur = -10;
+            t.setDate(t.getDate() - 10);
+            expect(formatDateTime(t, dur)).toContain(format(t, "do MMMM yyyy"));
+            expect(formatDateTime(t, dur)).toContain(format(t, "HH:mm"));
+            expect(formatDateTime(t, dur)).toEqual(`${format(t, "do MMMM yyyy HH:mm")}.`);
+        });
+    });
+});
+
+describe("Format relative date", () => {
+    const now = new Date();
+
+    it("Same minute", () => {
+        const t = new Date(now);
+        t.setSeconds(t.getSeconds() - 1);
+        expect(formatRelativeDate(t)).toEqual("A few seconds ago");
+    });
+
+    it("Same hour", () => {
+        const t = new Date(now);
+        t.setMinutes(t.getMinutes() - 1);
+        expect(formatRelativeDate(t)).toContain("This hour at");
+        expect(formatRelativeDate(t)).toContain(format(t, "HH:mm"));
+    });
+
+    it("Same day", () => {
+        const t = new Date(now);
+        t.setHours(t.getHours() - 1);
+        expect(formatRelativeDate(t)).toContain("Today at");
+        expect(formatRelativeDate(t)).toContain(format(t, "HH:mm"));
+    });
+
+    it("Same week", () => {
+        const t = new Date(now);
+        t.setDate(t.getDate() - 1);
+        expect(formatRelativeDate(t)).toContain(format(t, "EEEE"));
+        expect(formatRelativeDate(t)).toContain(format(t, "'at' HH:mm"));
+    });
+
+    it("Further ago than a week", () => {
+        const t = new Date(now);
+        t.setDate(t.getDate() - 10);
+        expect(formatRelativeDate(t)).toContain(format(t, "do MMMM yyyy"));
+        expect(formatRelativeDate(t)).toContain(format(t, "HH:mm"));
+    });
+
+    it("With leading zeros", () => {
+        const t = new Date("01 Jan 2000 00:00:00 GMT");
+        expect(formatRelativeDate(t)).toContain(format(t, "do MMMM yyyy"));
+        expect(formatRelativeDate(t)).toContain(format(t, "HH:mm"));
+    });
+});

--- a/src/Helpers/date.ts
+++ b/src/Helpers/date.ts
@@ -45,7 +45,7 @@ export const dateEqual = (value: Date, compare: Date): boolean => {
 };
 
 export const formatRFC3339DateTime = (d: Date): string => {
-    return format(d, "dd-MM-yyyy'T'HH:mm:ss");
+    return format(d, "yyyy-MM-dd'T'HH:mm:ss");
 };
 
 export const subDays = (d: Date, amount: number): Date => {

--- a/src/Helpers/date.ts
+++ b/src/Helpers/date.ts
@@ -1,13 +1,23 @@
-import { format, isSameDay, isSameHour, isSameMinute, isSameWeek } from "date-fns";
+import {
+    format,
+    isBefore as before,
+    isSameDay,
+    isSameHour,
+    isSameMinute,
+    isSameMonth,
+    isSameWeek,
+    isSameYear,
+    subDays as subtract
+} from "date-fns";
 
 
-export const formatDateTime = (d: Date, dur?: number): string => {
+export const formatRelativeDateTimeDuration = (d: Date, dur?: number): string => {
     return dur && dur > 0 ?
-        `${formatRelativeDate(d)} for ${dur} minutes.` :
-        `${formatRelativeDate(d)}.`;
+        `${formatRelativeDateTime(d)} for ${dur} minutes.` :
+        `${formatRelativeDateTime(d)}.`;
 };
 
-export const formatRelativeDate = (d: Date): string => {
+export const formatRelativeDateTime = (d: Date): string => {
     const now = new Date();
     if (isSameMinute(d, now)) {
         return "A few seconds ago";
@@ -20,4 +30,28 @@ export const formatRelativeDate = (d: Date): string => {
     } else {
         return format(d, "do MMMM yyyy HH:mm");
     }
+};
+
+export const dateEqual = (value: Date, compare: Date): boolean => {
+    if (!isSameYear(value, compare)) {
+        return false;
+    } else if (!isSameMonth(value, compare)) {
+        return false;
+    } else if (!isSameDay(value, compare)) {
+        return false;
+    } else {
+        return true;
+    }
+};
+
+export const formatRFC3339DateTime = (d: Date): string => {
+    return format(d, "dd-MM-yyyy'T'HH:mm:ss");
+};
+
+export const subDays = (d: Date, amount: number): Date => {
+    return subtract(d, amount);
+};
+
+export const isBefore = (d: Date, c: Date): boolean => {
+    return before(d, c);
 };

--- a/src/Helpers/date.ts
+++ b/src/Helpers/date.ts
@@ -1,0 +1,23 @@
+import { format, isSameDay, isSameHour, isSameMinute, isSameWeek } from "date-fns";
+
+
+export const formatDateTime = (d: Date, dur?: number): string => {
+    return dur && dur > 0 ?
+        `${formatRelativeDate(d)} for ${dur} minutes.` :
+        `${formatRelativeDate(d)}.`;
+};
+
+export const formatRelativeDate = (d: Date): string => {
+    const now = new Date();
+    if (isSameMinute(d, now)) {
+        return "A few seconds ago";
+    } else if (isSameHour(d, now)) {
+        return `This hour at ${format(d, "HH:mm")}`;
+    } else if (isSameDay(d, now)) {
+        return `Today at ${format(d, "HH:mm")}`;
+    } else if (isSameWeek(d, now)) {
+        return `${format(d, "EEEE")} at ${format(d, "HH:mm")}`;
+    } else {
+        return format(d, "do MMMM yyyy HH:mm");
+    }
+};

--- a/src/Model/filter.ts
+++ b/src/Model/filter.ts
@@ -1,4 +1,4 @@
-import { isSameDay, isSameMonth, isSameYear } from "date-fns";
+import { dateEqual } from "@helper/date";
 
 export interface Filter {
     startDate: Date,
@@ -37,18 +37,6 @@ export const isEqual = (value: Filter, compare: Filter): boolean => {
         }
     }
     return true;
-};
-
-const dateEqual = (value: Date, compare: Date): boolean => {
-    if (!isSameYear(value, compare)) {
-        return false;
-    } else if (!isSameMonth(value, compare)) {
-        return false;
-    } else if (!isSameDay(value, compare)) {
-        return false;
-    } else {
-        return true;
-    }
 };
 
 const arrayEquals = (value: string[], compare: string[]): boolean => {

--- a/src/Views/Filters/FiltersModal.view.tsx
+++ b/src/Views/Filters/FiltersModal.view.tsx
@@ -5,9 +5,8 @@ import { DatepickerRange } from "@zendeskgarden/react-datepickers";
 import { Field, Label, Input, Hint, Textarea } from "@zendeskgarden/react-forms";
 import { Modal as ZenModal, Header, Body, Footer, FooterItem, Close } from "@zendeskgarden/react-modals";
 
-import { isBefore } from "date-fns";
-
 import { Filter } from "@model/filter";
+import { isBefore } from "@helper/date";
 
 type Props = {
     onClose: (filter: Filter) => void,

--- a/src/Views/Table/Table.view.tsx
+++ b/src/Views/Table/Table.view.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import { Work } from "@model/work";
 
-import { format } from "date-fns";
+import { formatRelativeDateTime } from "@helper/date";
 
 type Props = {
     Worklist: Work[],
@@ -42,7 +42,7 @@ const Table: React.FC<Props> = (props: Props) => {
                                     {wl.Title}
                                 </td>
                                 <td className="text-gray-900 px-6 py-4 whitespace-nowrap">
-                                    {format(wl.When, "do MMMM yyyy HH:mm")}
+                                    {formatRelativeDateTime(wl.When)}
                                 </td>
                                 <td className="text-gray-900 px-6 py-4 whitespace-nowrap">
                                     {wl.Duration}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
             "@component/*": ["./src/Components/*"],
             "@view/*": ["./src/Views/*"],
             "@page/*": ["./src/Pages/*"],
+            "@helper/*": ["./src/Helpers/*"],
         },
         "types": [
             "jest",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
       "@component": path.resolve(__dirname, "./src/Components/"),
       "@view": path.resolve(__dirname, "./src/Views/"),
       "@page": path.resolve(__dirname, "./src/Pages/"),
+      "@helper": path.resolve(__dirname, "./src/Helpers/"),
     },
   },
 })


### PR DESCRIPTION
Move related date functions to a helper.

Only (not within the helper) date functions remaining should be within the tests.